### PR TITLE
Add multichannel support for u-net and u2^net. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+nbs/
+__pycache__/

--- a/semtorch/learner.py
+++ b/semtorch/learner.py
@@ -46,8 +46,6 @@ def check_architecture_configuration(number_classes, segmentation_type, architec
         raise BackboneNotSupportedError(backbone_name, architecture_config["backbones"])
 
     bad_config = True
-    print(architecture_config)
-    print(segmentation_type, number_classes)
     for supported_config in architecture_config["supported_configs"]:
         if (segmentation_type in supported_config["segmentation_type"] and number_classes in supported_config["number_of_classes"]):
             bad_config = False


### PR DESCRIPTION
Added support for more than three channels for u-net and u2^net. Examples shown in https://gist.github.com/jaeeolma/d628c116f78a73828d0d3b398dc84864. Will check whether it is possible to do this for other architectures also.

Also fixed check_architecture_configuration. Current version accepts u2^net and multiclass, for instance.

