### PR TITLE
Corrected channel numbers for deeplabv3 rn34 and 18

### DIFF
--- a/semtorch/models/archs/deeplabv3_plus.py
+++ b/semtorch/models/archs/deeplabv3_plus.py
@@ -24,6 +24,9 @@ class DeepLabV3Plus(SegBaseModel):
         if self.backbone_name.startswith('mobilenet'):
             c1_channels = 24
             c4_channels = 320
+        elif self.backbone_name in ['resnet34', 'resnet18'] :
+            c1_channels = 64
+            c4_channels = 512
         else:
             c1_channels = 256
             c4_channels = 2048


### PR DESCRIPTION
Original c1=256 and c4=2048 do not work for resnet34 and resnet18 backbone. Seems to need c1=64 and c4=256 to match the layers for resnet34 and resnet18.