### PR TITLE
HRNets small models key error in architecture_config dictionary

### DIFF
--- a/semtorch/models/archs/hrnet_seg.py
+++ b/semtorch/models/archs/hrnet_seg.py
@@ -18,10 +18,10 @@ BN_MOMENTUM = 0.01
 
 
 architecture_config = {
-    "hrnet_w18_small_v1": {
+    "hrnet_w18_small_model_v1": {
         "FINAL_CONV_KERNEL": 1
     },
-    "hrnet_w18_small_v2": {
+    "hrnet_w18_small_model_v2": {
         "FINAL_CONV_KERNEL": 1
     },
     "hrnet_w18": {


### PR DESCRIPTION
hrnet_w18_small_v1 and hrnet_w18_small_v2 keys are wrong in this achitecture_config dict. They must be hrnet_w18_small_model_v1 and hrnet_w18_small_model_v2. If not, when you try to train that models, the library crashes and gives you a key dictionary error. They must be the same that in architectures_config.json.